### PR TITLE
리뷰이벤트리스너 비동기 처리 

### DIFF
--- a/src/main/java/com/cloudingYo/barrierFree/common/AsyncConfig/AsyncConfig.java
+++ b/src/main/java/com/cloudingYo/barrierFree/common/AsyncConfig/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.cloudingYo.barrierFree.common.AsyncConfig;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/cloudingYo/barrierFree/review/service/ReviewEventListener.java
+++ b/src/main/java/com/cloudingYo/barrierFree/review/service/ReviewEventListener.java
@@ -1,0 +1,45 @@
+package com.cloudingYo.barrierFree.review.service;
+
+import com.cloudingYo.barrierFree.review.document.Review;
+import com.cloudingYo.barrierFree.review.dto.req.ReviewSavedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ReviewEventListener {
+    private final WebClient webClient;
+    private final RetryTemplate retryTemplate;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void triggerRecommandSystem(ReviewSavedEvent event){
+        Review review = event.getReview();
+        log.info("트랜잭션 커밋 후 ML 서버에 트리거 전송 시작... Review ID: {}", review.getId());
+
+        try {
+            retryTemplate.execute(context -> {
+                webClient.post()
+                        .uri("/update_recommend")
+                        .bodyValue(review)
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .doOnSuccess(response -> log.info("ML 서버 응답: {}", response))
+                        .doOnError(error -> log.error("ML 서버 트리거 실패 (재시도 중)... {}", error.getMessage()))
+                        .block();
+
+                return null;
+            });
+        } catch (Exception e) {
+            log.error("ML 서버 트리거 재시도 실패, 최종적으로 요청을 포기합니다. Review ID: {}", review.getId());
+        }
+    }
+}
+

--- a/src/main/java/com/cloudingYo/barrierFree/review/service/ReviewEventPublisher.java
+++ b/src/main/java/com/cloudingYo/barrierFree/review/service/ReviewEventPublisher.java
@@ -1,0 +1,19 @@
+package com.cloudingYo.barrierFree.review.service;
+
+import com.cloudingYo.barrierFree.review.document.Review;
+import com.cloudingYo.barrierFree.review.dto.req.ReviewSavedEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReviewEventPublisher {
+    private final ApplicationEventPublisher eventPublisher;
+
+    public ReviewEventPublisher(ApplicationEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    public void publishReviewSavedEvent(Review review) {
+        eventPublisher.publishEvent(new ReviewSavedEvent(review));
+    }
+}

--- a/src/main/java/com/cloudingYo/barrierFree/review/service/ReviewService.java
+++ b/src/main/java/com/cloudingYo/barrierFree/review/service/ReviewService.java
@@ -2,13 +2,11 @@ package com.cloudingYo.barrierFree.review.service;
 
 import com.cloudingYo.barrierFree.review.document.Review;
 import com.cloudingYo.barrierFree.review.dto.req.ReviewDTO;
-import com.cloudingYo.barrierFree.review.dto.req.ReviewSavedEvent;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.data.domain.Page;
 
 public interface ReviewService {
     Review createReview(ReviewDTO reviewDTO,HttpSession session) ;
-    void triggerRecommandSystem(ReviewSavedEvent event);
     Review deleteReview(Long placeKey, HttpSession session);
     Page<ReviewDTO> getReviewsByUserId(HttpSession session, int page);
     Page<ReviewDTO> getReviewsByPlaceKey(Long placeKey, int page,HttpSession session);

--- a/src/main/java/com/cloudingYo/barrierFree/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/cloudingYo/barrierFree/review/service/ReviewServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
@@ -47,6 +48,7 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void triggerRecommandSystem(ReviewSavedEvent event){
         Review review = event.getReview();

--- a/src/main/java/com/cloudingYo/barrierFree/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/cloudingYo/barrierFree/review/service/ReviewServiceImpl.java
@@ -4,23 +4,16 @@ import com.cloudingYo.barrierFree.place.entity.Place;
 import com.cloudingYo.barrierFree.place.repository.PlaceRepository;
 import com.cloudingYo.barrierFree.review.document.Review;
 import com.cloudingYo.barrierFree.review.dto.req.ReviewDTO;
-import com.cloudingYo.barrierFree.review.dto.req.ReviewSavedEvent;
 import com.cloudingYo.barrierFree.review.repository.ReviewRepository;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.retry.support.RetryTemplate;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
-import org.springframework.web.reactive.function.client.WebClient;
 
 @Slf4j
 @Service
@@ -29,9 +22,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class ReviewServiceImpl implements ReviewService {
     private final ReviewRepository reviewRepository;
     private final PlaceRepository placeRepository;
-    private final ApplicationEventPublisher eventPublisher;
-    private final WebClient webClient;
-    private final RetryTemplate retryTemplate;
+    private final ReviewEventPublisher reviewEventPublisher; // 이벤트 발행용 빈
 
     @Override
     public Review createReview(ReviewDTO reviewDTO, HttpSession session) {
@@ -42,34 +33,9 @@ public class ReviewServiceImpl implements ReviewService {
                 .content(reviewDTO.getContent())
                 .build());
 
-        // ReviewServiceImpl에서 리뷰 저장 후 이벤트 발행
-        eventPublisher.publishEvent(new ReviewSavedEvent(review));
+        // ✅ 이벤트 발행을 ReviewEventPublisher에서 수행
+        reviewEventPublisher.publishReviewSavedEvent(review);
         return review; // 트랜잭션 종료 시점
-    }
-
-    @Override
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void triggerRecommandSystem(ReviewSavedEvent event){
-        Review review = event.getReview();
-        log.info("트랜잭션 커밋 후 ML 서버에 트리거 전송 시작... Review ID: {}", review.getId());
-
-        try {
-            retryTemplate.execute(context -> {
-                webClient.post()
-                        .uri("/update_recommend")
-                        .bodyValue(review)
-                        .retrieve()
-                        .bodyToMono(String.class)
-                        .doOnSuccess(response -> log.info("ML 서버 응답: {}", response))
-                        .doOnError(error -> log.error("ML 서버 트리거 실패 (재시도 중)... {}", error.getMessage()))
-                        .block(); // 동기 실행하여 즉시 응답 확인
-
-                return null;
-            });
-        } catch (Exception e) {
-            log.error("ML 서버 트리거 재시도 실패, 최종적으로 요청을 포기합니다. Review ID: {}", review.getId());
-        }
     }
 
     @Override


### PR DESCRIPTION
ReviewServiceImpl 내부에서 this.triggerRecommandSystem(event); 같은 방식으로 호출하면 비동기로 실행되지 않음.

@Async와 @TransactionalEventListener(AFTER_COMMIT)를 함께 사용하면 비동기 실행이 트랜잭션 컨텍스트를 잃을 수 있다고 함.

해결 방법
@Async를 정상적으로 동작하게 하려면 서비스 클래스를 다른 Bean에서 호출해야 함
또는 비동기 이벤트 발행을 위한 별도 서비스 계층을 분리하는 것이 더 안전한 방법

따라서 리뷰이벤트 리스너와 퍼블리셔 객체를 따로 구현하였음